### PR TITLE
feat: add system tray icon support

### DIFF
--- a/src/main/java/org/araymond/joal/JackOfAllTradesApplication.java
+++ b/src/main/java/org/araymond/joal/JackOfAllTradesApplication.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class JackOfAllTradesApplication {
 
     public static void main(final String[] args) {
+        System.setProperty("java.awt.headless", "false");
         SpringApplication.run(JackOfAllTradesApplication.class, args);
     }
 }

--- a/src/main/java/org/araymond/joal/TrayIconManager.java
+++ b/src/main/java/org/araymond/joal/TrayIconManager.java
@@ -1,0 +1,63 @@
+package org.araymond.joal;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+@Profile("!test")
+@Component
+@Slf4j
+public class TrayIconManager implements ApplicationListener<ApplicationReadyEvent>, DisposableBean {
+    private final ConfigurableApplicationContext applicationContext;
+    private TrayIcon trayIcon;
+
+    @Inject
+    public TrayIconManager(final ConfigurableApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void onApplicationEvent(final ApplicationReadyEvent event) {
+        if (!SystemTray.isSupported()) {
+            log.warn("System tray not supported on this environment");
+            return;
+        }
+
+        try {
+            final SystemTray tray = SystemTray.getSystemTray();
+
+            final PopupMenu popup = new PopupMenu();
+            final MenuItem exitItem = new MenuItem("Exit");
+            exitItem.addActionListener(e -> applicationContext.close());
+            popup.add(exitItem);
+
+            final BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+            final Graphics2D g = image.createGraphics();
+            g.setColor(Color.BLACK);
+            g.fillRect(0, 0, 16, 16);
+            g.setColor(Color.WHITE);
+            g.drawString("J", 4, 12);
+            g.dispose();
+
+            trayIcon = new TrayIcon(image, "JOAL", popup);
+            tray.add(trayIcon);
+        } catch (final Exception e) {
+            log.warn("Failed to initialise system tray", e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (trayIcon != null) {
+            SystemTray.getSystemTray().remove(trayIcon);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable AWT headless mode to false for tray use
- add TrayIconManager to show JOAL in system tray with exit option

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a5005d54832692a0933a8174225a